### PR TITLE
Fast-track security updates in Renovate

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -7,6 +7,20 @@
   // サプライチェーン攻撃対策: 公開から14日間は様子を見る
   "minimumReleaseAge": "14 days",
 
+  // 脆弱性アラートは 14 日ルールを解除して即時 PR を出す
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "minimumReleaseAge": null,
+    "schedule": ["at any time"],
+    "labels": ["security"],
+  },
+
+  // OSV からの脆弱性検知も併用
+  "osvVulnerabilityAlerts": true,
+
+  // 間接依存 (transitive) の脆弱性を lockfile のみで修復する (npm)
+  "transitiveRemediation": true,
+
   "packageRules": [
     // Astro 関連をグルーピング
     {


### PR DESCRIPTION
## Summary
- `vulnerabilityAlerts` で 14 日の `minimumReleaseAge` を解除し、脆弱性修復 PR を即時で出す
- `osvVulnerabilityAlerts: true` で OSV 側からも検知
- `transitiveRemediation: true` で間接依存 (vite via astro 等) を lockfile のみで差し替え

## Context
GitHub security alert で Vite の脆弱性 4 件 (#41, #43, #44, #45, #46) が通知されているが、Vite は Astro 経由の transitive dep のため Renovate が PR を作っていない状態。これらはいずれも dev server に関する脆弱性で、本番の静的ビルドには影響しないがローカル開発環境の安全のために修復したい。

## Test plan
- [ ] Renovate が Vite 修復 PR を出すこと
- [ ] その PR の CI (build) がグリーンになること
- [ ] `npm run dev` / `npm run build` がローカルで動くこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)