### PR TITLE
Workflow cleanup, dynamic status badge, and notification fixes

### DIFF
--- a/.github/workflows/update_metrics.yml
+++ b/.github/workflows/update_metrics.yml
@@ -87,7 +87,7 @@ jobs:
         env:
           INCOMING_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         with:
-          text: Weight synced from D1!
+          text: "Weight updated! https://yasuharu519.github.io/weight/"
           attachments: |
             [
               {

--- a/.github/workflows/update_metrics.yml
+++ b/.github/workflows/update_metrics.yml
@@ -51,9 +51,9 @@ jobs:
             }' >> data.jsonl
 
             # 最新データを取得（通知用）
-            latest_weight=$(echo "$response" | jq -r '.result[0].results[-1].weight')
-            latest_fat_ratio=$(echo "$response" | jq -r '.result[0].results[-1].fat_ratio')
-            latest_muscle=$(echo "$response" | jq -r '.result[0].results[-1].muscle_mass')
+            latest_weight=$(echo "$response" | jq -r '(.result[0].results[-1].weight * 100 | round) / 100')
+            latest_fat_ratio=$(echo "$response" | jq -r '(.result[0].results[-1].fat_ratio * 100 | round) / 100')
+            latest_muscle=$(echo "$response" | jq -r '(.result[0].results[-1].muscle_mass * 100 | round) / 100')
             echo "latest_weight=${latest_weight}" >> "$GITHUB_OUTPUT"
             echo "latest_fat_ratio=${latest_fat_ratio}" >> "$GITHUB_OUTPUT"
             echo "latest_muscle=${latest_muscle}" >> "$GITHUB_OUTPUT"

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 - [Graph on Pixela](https://pixe.la/v1/users/yasuharu519/graphs/weight.html)
 
 
-[![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/yasuharu519/Weight?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/yasuharu519/weight?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 ## Current status
 ![weight](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fyasuharu519.github.io%2Fweight%2Flatest.json&query=%24.weight&label=weight&suffix=%20kg&color=blue&cacheSeconds=3600)

--- a/README.md
+++ b/README.md
@@ -3,12 +3,10 @@
 - [Graph on Pixela](https://pixe.la/v1/users/yasuharu519/graphs/weight.html)
 
 
-[![Gitter](https://badges.gitter.im/Join Chat.svg)](https://gitter.im/yasuharu519/Weight?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/yasuharu519/Weight?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-## Curent status
-- **Current weight** : 79.6kg
-- **Current body fat percentage** : 20.6%
+## Current status
+![weight](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fyasuharu519.github.io%2Fweight%2Flatest.json&query=%24.weight&label=weight&suffix=%20kg&color=blue&cacheSeconds=3600)
+![body fat](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fyasuharu519.github.io%2Fweight%2Flatest.json&query=%24.fatPercent&label=body%20fat&suffix=%20%25&color=orange&cacheSeconds=3600)
 
-[グラフ](http://yasuharu519.github.io/Weight/)
-
-
+[グラフ](https://yasuharu519.github.io/weight/)

--- a/dashboard/src/pages/latest.json.ts
+++ b/dashboard/src/pages/latest.json.ts
@@ -1,0 +1,18 @@
+import type { APIRoute } from "astro";
+import { loadData } from "../lib/data";
+
+// ビルド時に dist/latest.json を生成する静的エンドポイント。
+// GitHub Pages 上の https://yasuharu519.github.io/weight/latest.json として配信され、
+// README の shields.io dynamic badge がこれを参照する。
+export const GET: APIRoute = () => {
+  const records = loadData(); // date 昇順ソート済み（src/lib/data.ts）
+  const latest = records[records.length - 1];
+  return new Response(
+    JSON.stringify({
+      date: latest.date,
+      weight: latest.weight,
+      fatPercent: latest.fatPercent,
+    }),
+    { headers: { "content-type": "application/json" } },
+  );
+};


### PR DESCRIPTION
## Summary
- Remove unused `update_metrics.yml` (superseded by hourly D1 sync) and drop its stale `workflow_run` reference in `deploy.yml`
- Add the dashboard URL to the Slack sync notification
- Replace the hand-maintained "Current status" in README with shields.io dynamic badges, backed by a new `latest.json` Astro build endpoint — README stays static and there is **no per-sync commit churn** (`dist/` is gitignored). Also fixes the broken dashboard link, the Gitter badge markdown, and a heading typo
- Round Slack/Pixela notification values (weight / fat_ratio / muscle) to 2 decimals to remove float artifacts like `62.620000000000005`

## Test plan
- [ ] CI (dashboard build) passes
- [ ] After merge to `main`, `deploy.yml` publishes https://yasuharu519.github.io/weight/latest.json
- [ ] README badges render the latest weight / body-fat
- [ ] Next D1 sync posts a Slack message with 2-decimal values and the dashboard URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)