### PR TITLE
Disable credential persistence in checkout steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        persist-credentials: false
     - name: Install pnpm
       uses: pnpm/action-setup@d15e628ca66d93ee5f352c71671a7bc6a97af5c9 # v6.0.8
       with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,6 +28,8 @@ jobs:
     if: ${{ github.event_name == 'push' || github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - name: Install pnpm
         uses: pnpm/action-setup@d15e628ca66d93ee5f352c71671a7bc6a97af5c9 # v6.0.8
         with:

--- a/.github/workflows/update_metrics.yml
+++ b/.github/workflows/update_metrics.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Get last synced datetime
         id: last_date

--- a/.github/workflows/update_metrics.yml
+++ b/.github/workflows/update_metrics.yml
@@ -69,9 +69,10 @@ jobs:
           git add data.jsonl
           datetime=$(date '+%F %T')
           git commit -m "Sync weight data from D1 on ${datetime}"
-          git push
+          git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:${GITHUB_REF_NAME}"
         env:
           TZ: Asia/Tokyo
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Post on Pixela
         if: steps.fetch.outputs.count != '0'


### PR DESCRIPTION
## Summary
- Add `persist-credentials: false` to `actions/checkout` in `ci.yml`, `deploy.yml`, and `update_metrics.yml`
- Prevents the `GITHUB_TOKEN` from being left in the local git config after checkout, reducing the risk of token leakage to subsequent steps/actions

## Test plan
- [ ] CI workflow runs successfully
- [ ] Deploy workflow runs successfully
- [ ] update_metrics workflow can still commit/push synced data (verify pushing still works with explicit credentials where needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)