### PR TITLE
ダッシュボードのデザイン修正と月次トレンドの作り直し

### DIFF
--- a/dashboard/src/components/BodyCompChart.astro
+++ b/dashboard/src/components/BodyCompChart.astro
@@ -15,7 +15,7 @@ const dataJson = JSON.stringify(bodyCompData);
 {bodyCompData.length > 0 && (
   <div class="bg-card rounded-2xl border border-border p-4 md:p-6 shadow-sm mb-6 md:mb-8 animate-fade-up" style="animation-delay: 0.28s;">
     <div class="flex items-center justify-between mb-4 md:mb-5">
-      <h2 class="font-display text-base md:text-lg font-500 tracking-tight text-ink">ボディコンポジション</h2>
+      <h2 class="font-display text-base md:text-lg font-medium tracking-tight text-ink">ボディコンポジション</h2>
       <div class="flex gap-1 md:gap-1.5" id="bodycomp-period-buttons">
         <button data-period="1" class="bodycomp-btn">1M</button>
         <button data-period="3" class="bodycomp-btn">3M</button>

--- a/dashboard/src/components/FatChart.astro
+++ b/dashboard/src/components/FatChart.astro
@@ -13,7 +13,7 @@ const maJson = JSON.stringify(movingAvg);
 
 <div class="bg-card rounded-2xl border border-border p-4 md:p-6 shadow-sm mb-6 md:mb-8 animate-fade-up" style="animation-delay: 0.24s;">
   <div class="flex items-center justify-between mb-4 md:mb-5">
-    <h2 class="font-display text-base md:text-lg font-500 tracking-tight text-ink">体脂肪率</h2>
+    <h2 class="font-display text-base md:text-lg font-medium tracking-tight text-ink">体脂肪率</h2>
     <div class="flex gap-1 md:gap-1.5" id="fat-period-buttons">
       <button data-period="1" class="fat-period-btn">1M</button>
       <button data-period="3" class="fat-period-btn">3M</button>

--- a/dashboard/src/components/MetabolicsCards.astro
+++ b/dashboard/src/components/MetabolicsCards.astro
@@ -24,7 +24,7 @@ const metrics = latest
 
 {latest && (
   <div class="animate-fade-up" style="animation-delay: 0.36s;">
-    <h2 class="font-display text-base md:text-lg font-500 tracking-tight text-ink mb-4">メタボリクス・体組成</h2>
+    <h2 class="font-display text-base md:text-lg font-medium tracking-tight text-ink mb-4">メタボリクス・体組成</h2>
     <div class="grid grid-cols-2 md:grid-cols-3 gap-4 md:gap-5 mb-6 md:mb-8">
       {metrics.map((m) => (
         <div class="bg-card rounded-2xl border border-border p-5 shadow-sm">
@@ -32,7 +32,7 @@ const metrics = latest
             <span class={`w-1.5 h-1.5 rounded-full ${m.color} shrink-0`}></span>
             <p class="text-[0.65rem] font-medium tracking-[0.12em] uppercase text-ink-muted">{m.label}</p>
           </div>
-          <p class="font-display text-2xl md:text-3xl font-600 tracking-tight text-ink leading-none">
+          <p class="font-display text-2xl md:text-3xl font-semibold tracking-tight text-ink leading-none">
             {m.value}
             {m.unit && <span class="text-sm md:text-base font-body font-normal text-ink-muted ml-0.5">{m.unit}</span>}
           </p>

--- a/dashboard/src/components/MonthlyTrend.astro
+++ b/dashboard/src/components/MonthlyTrend.astro
@@ -10,14 +10,15 @@ const dataJson = JSON.stringify(data);
 ---
 
 <div class="bg-card rounded-2xl border border-border p-4 md:p-6 shadow-sm mb-6 md:mb-8 animate-fade-up" style="animation-delay: 0.32s;">
-  <div class="flex items-center justify-between mb-4 md:mb-5">
-    <h2 class="font-display text-base md:text-lg font-500 tracking-tight text-ink">月次トレンド</h2>
+  <div class="flex items-center justify-between mb-1">
+    <h2 class="font-display text-base md:text-lg font-medium tracking-tight text-ink">月次トレンド</h2>
     <div class="flex gap-1 md:gap-1.5" id="monthly-period-buttons">
-      <button data-period="2" class="monthly-btn monthly-active">2Y</button>
+      <button data-period="2" class="monthly-btn">2Y</button>
       <button data-period="5" class="monthly-btn">5Y</button>
-      <button data-period="all" class="monthly-btn">ALL</button>
+      <button data-period="all" class="monthly-btn monthly-active">ALL</button>
     </div>
   </div>
+  <p class="text-xs text-ink-muted mb-4 md:mb-5">月平均体重と前月比の増減(橙 = 増・緑 = 減)</p>
   <div class="h-[260px] md:h-[320px]">
     <canvas id="monthly-chart"></canvas>
   </div>
@@ -45,66 +46,105 @@ const dataJson = JSON.stringify(data);
 
   const data = (window as any).__monthlyData;
 
-  const years = [...new Set(data.map((d: any) => d.year))] as number[];
-  const palette = [
-    "rgba(67, 56, 202, 0.55)",
-    "rgba(194, 65, 12, 0.50)",
-    "rgba(21, 128, 61, 0.50)",
-    "rgba(147, 51, 234, 0.50)",
-    "rgba(202, 138, 4, 0.50)",
-    "rgba(14, 116, 144, 0.50)",
-    "rgba(190, 18, 60, 0.50)",
-    "rgba(79, 70, 229, 0.45)",
-    "rgba(234, 88, 12, 0.45)",
-    "rgba(22, 163, 74, 0.45)",
-    "rgba(168, 85, 247, 0.45)",
-  ];
+  // 欠測月も含む連続した月軸を作り、データのない月は null にする。
+  // こうすると 2024→2026 のような欠測期間が線の途切れとして正直に表示される
+  const byMonth = new Map<string, number>(
+    data.map((d: any) => [d.month, d.weight]),
+  );
+  const first = data[0].month;
+  const last = data[data.length - 1].month;
 
-  const yearColors = new Map<number, string>();
-  years.forEach((y, i) => yearColors.set(y, palette[i % palette.length]));
+  const allMonths: string[] = [];
+  {
+    let [y, m] = first.split("-").map(Number);
+    const [ly, lm] = last.split("-").map(Number);
+    while (y < ly || (y === ly && m <= lm)) {
+      allMonths.push(`${y}-${String(m).padStart(2, "0")}`);
+      m++;
+      if (m > 12) { m = 1; y++; }
+    }
+  }
 
-  const allMonths = data.map((d: any) => d.month);
-  const allWeights = data.map((d: any) => d.weight);
-  const allColors = data.map((d: any) => yearColors.get(d.year));
+  const allWeights = allMonths.map((m) => byMonth.get(m) ?? null);
+  // 前月比: 連続する2か月ともデータがある場合のみ算出
+  const allDeltas = allMonths.map((m, i) => {
+    if (i === 0) return null;
+    const cur = allWeights[i];
+    const prev = allWeights[i - 1];
+    if (cur == null || prev == null) return null;
+    return Math.round((cur - prev) * 100) / 100;
+  });
+
+  const WARM = "rgba(194, 65, 12, 0.55)";
+  const SAGE = "rgba(21, 128, 61, 0.5)";
+  const deltaColors = (deltas: (number | null)[]) =>
+    deltas.map((d) => (d != null && d > 0 ? WARM : SAGE));
 
   function getFilteredData(periodYears: number | "all") {
-    if (periodYears === "all") {
-      return { months: allMonths, weights: allWeights, colors: allColors };
-    }
-    const lastMonth = allMonths[allMonths.length - 1];
-    const lastDate = new Date(lastMonth + "-01");
-    const cutoff = new Date(lastDate);
-    cutoff.setFullYear(cutoff.getFullYear() - periodYears);
-    const cutoffMonth = `${cutoff.getFullYear()}-${String(cutoff.getMonth() + 1).padStart(2, "0")}`;
-    const startIdx = allMonths.findIndex((m: string) => m >= cutoffMonth);
-    if (startIdx < 0) return { months: allMonths, weights: allWeights, colors: allColors };
+    const start =
+      periodYears === "all"
+        ? 0
+        : Math.max(0, allMonths.length - periodYears * 12);
+    const weights = allWeights.slice(start);
+    const present = weights.filter((w): w is number => w != null);
     return {
-      months: allMonths.slice(startIdx),
-      weights: allWeights.slice(startIdx),
-      colors: allColors.slice(startIdx),
+      months: allMonths.slice(start),
+      weights,
+      deltas: allDeltas.slice(start),
+      // 体重軸は 0 始まりだと変化が見えないため、データ範囲±1kg に絞る
+      yMin: Math.floor(Math.min(...present)) - 1,
+      yMax: Math.ceil(Math.max(...present)) + 1,
     };
   }
 
-  const initial = getFilteredData(2);
+  const initial = getFilteredData("all");
 
   const chart = new Chart(document.getElementById("monthly-chart") as HTMLCanvasElement, {
     type: "bar",
     data: {
       labels: initial.months,
-      datasets: [{
-        label: "月平均体重",
-        data: initial.weights,
-        backgroundColor: initial.colors,
-        borderWidth: 0,
-        borderRadius: 4,
-        borderSkipped: false,
-      }],
+      datasets: [
+        {
+          type: "line" as const,
+          label: "月平均体重",
+          data: initial.weights,
+          borderColor: "rgba(67, 56, 202, 0.8)",
+          backgroundColor: "rgba(67, 56, 202, 0.8)",
+          borderWidth: 2,
+          pointRadius: 0,
+          pointHitRadius: 10,
+          tension: 0.3,
+          spanGaps: false,
+          yAxisID: "y",
+        },
+        {
+          type: "bar" as const,
+          label: "前月比",
+          data: initial.deltas,
+          backgroundColor: deltaColors(initial.deltas),
+          borderWidth: 0,
+          borderRadius: 2,
+          borderSkipped: false,
+          yAxisID: "y1",
+        },
+      ],
     },
     options: {
       responsive: true,
       maintainAspectRatio: false,
+      interaction: { mode: "index", intersect: false },
       plugins: {
-        legend: { display: false },
+        legend: {
+          display: true,
+          position: "top",
+          labels: {
+            font: { family: "'Plus Jakarta Sans', system-ui", size: 11 },
+            color: "#6b7280",
+            usePointStyle: true,
+            pointStyle: "circle",
+            padding: 16,
+          },
+        },
         tooltip: {
           backgroundColor: "#fff",
           titleColor: "#1a1a1a",
@@ -116,18 +156,38 @@ const dataJson = JSON.stringify(data);
           padding: 14,
           cornerRadius: 12,
           callbacks: {
-            label: (item) => `${item.raw} kg`,
+            label: (item) => {
+              if (item.raw == null) return "";
+              const v = item.raw as number;
+              if (item.dataset.label === "前月比") {
+                return `前月比:  ${v > 0 ? "+" : ""}${v} kg`;
+              }
+              return `月平均:  ${v} kg`;
+            },
           },
         },
       },
       scales: {
         x: {
-          ticks: { maxTicksLimit: 20, padding: 8 },
+          ticks: { maxTicksLimit: 14, padding: 8 },
           grid: { display: false },
         },
         y: {
+          position: "left",
+          min: initial.yMin,
+          max: initial.yMax,
           ticks: { padding: 14 },
           grid: { color: "rgba(0,0,0,0.03)" },
+          title: { display: true, text: "kg", color: "#9ca3af" },
+        },
+        y1: {
+          position: "right",
+          // 0 を中心に上下対称のレンジにして増減を読み取りやすくする
+          suggestedMin: -2,
+          suggestedMax: 2,
+          ticks: { padding: 12 },
+          grid: { display: false },
+          title: { display: true, text: "前月比 (kg)", color: "#9ca3af" },
         },
       },
     },
@@ -144,7 +204,10 @@ const dataJson = JSON.stringify(data);
     const filtered = getFilteredData(period === "all" ? "all" : parseInt(period));
     chart.data.labels = filtered.months;
     chart.data.datasets[0].data = filtered.weights;
-    chart.data.datasets[0].backgroundColor = filtered.colors;
+    chart.data.datasets[1].data = filtered.deltas;
+    chart.data.datasets[1].backgroundColor = deltaColors(filtered.deltas);
+    chart.options.scales!.y!.min = filtered.yMin;
+    chart.options.scales!.y!.max = filtered.yMax;
     chart.update();
   });
 </script>

--- a/dashboard/src/components/SummaryCards.astro
+++ b/dashboard/src/components/SummaryCards.astro
@@ -18,7 +18,7 @@ const wowArrow = weekOverWeek != null ? (weekOverWeek <= 0 ? "\u2198" : "\u2197"
   <!-- Latest Weight -->
   <div class="bg-card rounded-2xl border border-border p-6 shadow-sm">
     <p class="text-[0.65rem] font-medium tracking-[0.12em] uppercase text-ink-muted mb-3">最新体重</p>
-    <p class="font-display text-2xl md:text-4xl font-600 tracking-tight text-ink leading-none">
+    <p class="font-display text-2xl md:text-4xl font-semibold tracking-tight text-ink leading-none">
       {latestWeight}
       <span class="text-base font-body font-normal text-ink-muted ml-0.5">kg</span>
     </p>
@@ -29,20 +29,20 @@ const wowArrow = weekOverWeek != null ? (weekOverWeek <= 0 ? "\u2198" : "\u2197"
   <div class="bg-card rounded-2xl border border-border p-6 shadow-sm">
     <p class="text-[0.65rem] font-medium tracking-[0.12em] uppercase text-ink-muted mb-3">前週比</p>
     {weekOverWeek != null ? (
-      <p class={`font-display text-2xl md:text-4xl font-600 tracking-tight leading-none ${wowPositive ? "text-warm" : "text-sage"}`}>
+      <p class={`font-display text-2xl md:text-4xl font-semibold tracking-tight leading-none ${wowPositive ? "text-warm" : "text-sage"}`}>
         {wowSign}{weekOverWeek}
         <span class="text-base font-body font-normal ml-0.5">kg</span>
         <span class="text-lg ml-1">{wowArrow}</span>
       </p>
     ) : (
-      <p class="font-display text-2xl md:text-4xl font-600 text-ink-muted leading-none">—</p>
+      <p class="font-display text-2xl md:text-4xl font-semibold text-ink-muted leading-none">—</p>
     )}
   </div>
 
   <!-- 30d Moving Average -->
   <div class="bg-card rounded-2xl border border-border p-6 shadow-sm">
     <p class="text-[0.65rem] font-medium tracking-[0.12em] uppercase text-ink-muted mb-3">30日平均</p>
-    <p class="font-display text-2xl md:text-4xl font-600 tracking-tight text-ink leading-none">
+    <p class="font-display text-2xl md:text-4xl font-semibold tracking-tight text-ink leading-none">
       {movingAvg30}
       <span class="text-base font-body font-normal text-ink-muted ml-0.5">kg</span>
     </p>
@@ -51,7 +51,7 @@ const wowArrow = weekOverWeek != null ? (weekOverWeek <= 0 ? "\u2198" : "\u2197"
   <!-- BMI -->
   <div class="bg-card rounded-2xl border border-border p-6 shadow-sm">
     <p class="text-[0.65rem] font-medium tracking-[0.12em] uppercase text-ink-muted mb-3">BMI</p>
-    <p class="font-display text-2xl md:text-4xl font-600 tracking-tight text-ink leading-none">
+    <p class="font-display text-2xl md:text-4xl font-semibold tracking-tight text-ink leading-none">
       {bmi}
     </p>
   </div>

--- a/dashboard/src/components/WeightChart.astro
+++ b/dashboard/src/components/WeightChart.astro
@@ -13,7 +13,7 @@ const maJson = JSON.stringify(movingAvg);
 
 <div class="bg-card rounded-2xl border border-border p-4 md:p-6 shadow-sm mb-6 md:mb-8 animate-fade-up" style="animation-delay: 0.16s;">
   <div class="flex items-center justify-between mb-4 md:mb-5">
-    <h2 class="font-display text-base md:text-lg font-500 tracking-tight text-ink">体重</h2>
+    <h2 class="font-display text-base md:text-lg font-medium tracking-tight text-ink">体重</h2>
     <div class="flex gap-1 md:gap-1.5" id="weight-period-buttons">
       <button data-period="1" class="period-btn">1M</button>
       <button data-period="3" class="period-btn">3M</button>
@@ -59,6 +59,9 @@ const maJson = JSON.stringify(movingAvg);
   Chart.defaults.font.size = 11;
   Chart.defaults.color = "#9ca3af";
   Chart.defaults.borderColor = "rgba(0,0,0,0.04)";
+  if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+    Chart.defaults.animation = false;
+  }
 
   const chart = new Chart(document.getElementById("weight-chart") as HTMLCanvasElement, {
     type: "line",

--- a/dashboard/src/components/YearlyStats.astro
+++ b/dashboard/src/components/YearlyStats.astro
@@ -9,7 +9,7 @@ const { data } = Astro.props;
 ---
 
 <div class="bg-card rounded-2xl border border-border p-4 md:p-6 shadow-sm animate-fade-up" style="animation-delay: 0.4s;">
-  <h2 class="font-display text-base md:text-lg font-500 tracking-tight text-ink mb-4 md:mb-5">年次統計</h2>
+  <h2 class="font-display text-base md:text-lg font-medium tracking-tight text-ink mb-4 md:mb-5">年次統計</h2>
   <div class="overflow-x-auto">
     <table class="w-full text-sm">
       <thead>
@@ -24,7 +24,7 @@ const { data } = Astro.props;
       <tbody>
         {data.map((row, i) => (
           <tr class="border-b border-gray-50 hover:bg-surface/50 transition-colors">
-            <td class="py-3 px-4 font-display font-500 text-ink">{row.year}</td>
+            <td class="py-3 px-4 font-display font-medium text-ink">{row.year}</td>
             <td class="py-3 px-4 text-right font-body text-ink-secondary tabular-nums">{row.avgWeight} <span class="text-ink-muted text-xs">kg</span></td>
             <td class="py-3 px-4 text-right font-body text-ink-secondary tabular-nums">{row.minWeight} <span class="text-ink-muted text-xs">kg</span></td>
             <td class="py-3 px-4 text-right font-body text-ink-secondary tabular-nums">{row.maxWeight} <span class="text-ink-muted text-xs">kg</span></td>

--- a/dashboard/src/layouts/Layout.astro
+++ b/dashboard/src/layouts/Layout.astro
@@ -24,7 +24,7 @@ import "../styles/global.css";
     <div class="relative z-10">
       <header class="max-w-5xl mx-auto px-4 md:px-8 pt-8 md:pt-12 pb-2 animate-fade-up">
         <div class="flex items-baseline gap-4">
-          <h1 class="font-display text-3xl font-500 tracking-tight text-ink" style="font-variation-settings: 'SOFT' 100, 'WONK' 1;">Weight</h1>
+          <h1 class="font-display text-3xl font-medium tracking-tight text-ink" style="font-variation-settings: 'SOFT' 100, 'WONK' 1;">Weight</h1>
           <span class="text-[0.65rem] font-medium tracking-[0.15em] uppercase text-ink-muted">Journal</span>
         </div>
         <div class="mt-2 w-12 h-[2px] bg-accent rounded-full"></div>
@@ -36,7 +36,7 @@ import "../styles/global.css";
 
       <footer class="max-w-5xl mx-auto px-4 md:px-8 pb-12">
         <div class="border-t border-border pt-6">
-          <p class="text-xs text-ink-muted">Tracking since 2014 &middot; {new Date().getFullYear()}</p>
+          <p class="text-xs text-ink-muted">Tracking since 2014</p>
         </div>
       </footer>
     </div>

--- a/dashboard/src/styles/global.css
+++ b/dashboard/src/styles/global.css
@@ -16,9 +16,28 @@
 
   --font-display: "Fraunces", Georgia, serif;
   --font-body: "Plus Jakarta Sans", system-ui, sans-serif;
+
+  --animate-fade-up: fade-up 0.6s ease-out both;
+
+  @keyframes fade-up {
+    from {
+      opacity: 0;
+      transform: translateY(12px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
 }
 
 html {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .animate-fade-up {
+    animation: none;
+  }
 }


### PR DESCRIPTION
## Summary
- **壊れていた Tailwind クラスを修正**: `font-500`/`font-600` は Tailwind v4 では無効でCSSが生成されず、見出し・数値が太字になっていなかった。`font-medium`/`font-semibold` に置換
- **フェードインアニメーションを実際に動くように**: `animate-fade-up` が未定義で全カードの登場演出が効いていなかった。`global.css` に `fade-up` キーフレームと `--animate-fade-up` を定義
- **`prefers-reduced-motion` 対応を追加**(CSSアニメーションと Chart.js 両方)
- **月次トレンドを作り直し**: 年ごと色分けの棒グラフ(ほぼ同じ高さで差が読めず無意味だった)を廃止。月平均体重を折れ線(軸を実データ範囲にズーム)+ 前月比を増減バー(橙=増・緑=減)に変更。欠測月は線を途切れさせて正直に表示
- **フッター表記を整理**: `Tracking since 2014 · 2026` → `Tracking since 2014`

## Test plan
- [ ] `pnpm build` が成功する
- [ ] 生成CSSに `font-medium` / `@keyframes fade-up` が含まれる
- [ ] 月次トレンドで折れ線と増減バーが読み取れる
- [ ] カードのフェードイン演出が動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)