### PR TITLE
Add sleep section to dashboard

### DIFF
--- a/dashboard/src/components/SleepChart.astro
+++ b/dashboard/src/components/SleepChart.astro
@@ -1,0 +1,191 @@
+---
+import type { SleepRecord } from "../lib/sleep";
+
+interface Props {
+  data: SleepRecord[];
+}
+
+const { data } = Astro.props;
+const dataJson = JSON.stringify(data);
+---
+
+<div class="bg-card rounded-2xl border border-border p-4 md:p-6 shadow-sm mb-6 md:mb-8 animate-fade-up" style="animation-delay: 0.44s;">
+  <div class="flex items-center justify-between mb-4 md:mb-5">
+    <h2 class="font-display text-base md:text-lg font-medium tracking-tight text-ink">睡眠</h2>
+    <div class="flex gap-1 md:gap-1.5" id="sleep-period-buttons">
+      <button data-period="1" class="sleep-btn">1M</button>
+      <button data-period="3" class="sleep-btn">3M</button>
+      <button data-period="6" class="sleep-btn">6M</button>
+      <button data-period="12" class="sleep-btn">1Y</button>
+      <button data-period="all" class="sleep-btn sleep-active">ALL</button>
+    </div>
+  </div>
+  <div class="h-[280px] md:h-[380px]">
+    <canvas id="sleep-chart"></canvas>
+  </div>
+</div>
+
+<style>
+  @reference "../styles/global.css";
+  .sleep-btn {
+    @apply text-[0.7rem] font-medium tracking-wide px-3 py-1 rounded-full
+           border border-transparent text-ink-muted
+           hover:text-ink-secondary hover:bg-gray-50
+           transition-all duration-200 cursor-pointer;
+  }
+  .sleep-active {
+    @apply bg-accent-soft text-accent border-indigo-200;
+  }
+</style>
+
+<script is:inline define:vars={{ dataJson }}>
+  window.__sleepData = JSON.parse(dataJson);
+</script>
+
+<script>
+  import Chart from "chart.js/auto";
+
+  const data = (window as any).__sleepData;
+  if (data && data.length > 0) {
+    const toHours = (sec: number) => Math.round((sec / 3600) * 100) / 100;
+    const formatDuration = (seconds: number) => {
+      const totalMinutes = Math.round(seconds / 60);
+      const h = Math.floor(totalMinutes / 60);
+      const m = totalMinutes % 60;
+      return `${h}h ${String(m).padStart(2, "0")}m`;
+    };
+
+    const allDates = data.map((d: any) => d.date);
+    const allDeep = data.map((d: any) => toHours(d.deep));
+    const allLight = data.map((d: any) => toHours(d.light));
+    const allRem = data.map((d: any) => toHours(d.rem));
+    const allWaso = data.map((d: any) => toHours(d.waso));
+
+    const chart = new Chart(document.getElementById("sleep-chart") as HTMLCanvasElement, {
+      type: "bar",
+      data: {
+        labels: allDates,
+        datasets: [
+          {
+            label: "深い",
+            data: allDeep,
+            backgroundColor: "rgba(67, 56, 202, 0.85)",
+          },
+          {
+            label: "浅い",
+            data: allLight,
+            backgroundColor: "rgba(99, 102, 241, 0.45)",
+          },
+          {
+            label: "REM",
+            data: allRem,
+            backgroundColor: "rgba(129, 140, 248, 0.25)",
+          },
+          {
+            label: "中途覚醒",
+            data: allWaso,
+            backgroundColor: "rgba(156, 163, 175, 0.35)",
+          },
+        ],
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        interaction: { mode: "index", intersect: false },
+        plugins: {
+          legend: {
+            display: true,
+            position: "top",
+            labels: {
+              font: { family: "'Plus Jakarta Sans', system-ui", size: 11 },
+              color: "#6b7280",
+              usePointStyle: true,
+              pointStyle: "circle",
+              padding: 16,
+            },
+          },
+          tooltip: {
+            backgroundColor: "#fff",
+            titleColor: "#1a1a1a",
+            bodyColor: "#6b7280",
+            footerColor: "#1a1a1a",
+            borderColor: "#e8e4df",
+            borderWidth: 1,
+            titleFont: { family: "'Fraunces', Georgia, serif", weight: "500", size: 13 },
+            bodyFont: { family: "'Plus Jakarta Sans', system-ui", size: 12 },
+            footerFont: { family: "'Plus Jakarta Sans', system-ui", size: 12, weight: "500" },
+            padding: 14,
+            cornerRadius: 12,
+            boxPadding: 6,
+            callbacks: {
+              label: (item: any) => {
+                const idx = allDates.indexOf(item.chart.data.labels[item.dataIndex]);
+                const record = data[idx];
+                const seconds = { 深い: record.deep, 浅い: record.light, REM: record.rem, 中途覚醒: record.waso }[
+                  item.dataset.label as string
+                ];
+                return `${item.dataset.label}:  ${formatDuration(seconds)}`;
+              },
+              footer: (items: any[]) => {
+                const idx = allDates.indexOf(items[0].chart.data.labels[items[0].dataIndex]);
+                const record = data[idx];
+                const lines = [`合計:  ${formatDuration(record.totalSleepTime)}`];
+                if (record.score != null) lines.push(`スコア:  ${record.score}/100`);
+                if (record.wakeupCount != null) lines.push(`中途覚醒:  ${record.wakeupCount}回`);
+                return lines;
+              },
+            },
+          },
+        },
+        scales: {
+          x: {
+            stacked: true,
+            ticks: { maxTicksLimit: 10, padding: 10 },
+            grid: { display: false },
+          },
+          y: {
+            stacked: true,
+            ticks: { padding: 14 },
+            grid: { color: "rgba(0,0,0,0.03)" },
+            title: { display: true, text: "時間 (h)", color: "#9ca3af" },
+          },
+        },
+      },
+    });
+
+    const allSeries = [allDeep, allLight, allRem, allWaso];
+
+    function filterByMonths(months: number | "all") {
+      if (months === "all") {
+        chart.data.labels = allDates;
+        allSeries.forEach((series, i) => {
+          chart.data.datasets[i].data = series;
+        });
+      } else {
+        const lastDate = new Date(allDates[allDates.length - 1]);
+        const cutoff = new Date(lastDate);
+        cutoff.setMonth(cutoff.getMonth() - months);
+        const cutoffStr = cutoff.toISOString().split("T")[0];
+        const startIdx = allDates.findIndex((d: string) => d >= cutoffStr);
+        if (startIdx >= 0) {
+          chart.data.labels = allDates.slice(startIdx);
+          allSeries.forEach((series, i) => {
+            chart.data.datasets[i].data = series.slice(startIdx);
+          });
+        }
+      }
+      chart.update();
+    }
+
+    document.getElementById("sleep-period-buttons")?.addEventListener("click", (e) => {
+      const btn = (e.target as HTMLElement).closest("button");
+      if (!btn) return;
+      const period = btn.dataset.period!;
+      document.querySelectorAll("#sleep-period-buttons button").forEach((b) => {
+        b.className = "sleep-btn";
+      });
+      btn.classList.add("sleep-active");
+      filterByMonths(period === "all" ? "all" : parseInt(period));
+    });
+  }
+</script>

--- a/dashboard/src/components/SleepSummaryCards.astro
+++ b/dashboard/src/components/SleepSummaryCards.astro
@@ -1,0 +1,58 @@
+---
+import type { SleepStats } from "../lib/sleep";
+import { formatDuration } from "../lib/sleep";
+
+interface Props {
+  stats: SleepStats;
+}
+
+const { stats } = Astro.props;
+const { latest, avg7dSleepTime, deepRatioPercent } = stats;
+---
+
+<div class="grid grid-cols-2 md:grid-cols-4 gap-4 md:gap-5 mb-6 md:mb-8 animate-fade-up" style="animation-delay: 0.4s;">
+  <!-- Last Night -->
+  <div class="bg-card rounded-2xl border border-border p-6 shadow-sm">
+    <p class="text-[0.65rem] font-medium tracking-[0.12em] uppercase text-ink-muted mb-3">昨夜の睡眠</p>
+    <p class="font-display text-2xl md:text-4xl font-semibold tracking-tight text-ink leading-none">
+      {formatDuration(latest.totalSleepTime)}
+    </p>
+    <p class="text-xs text-ink-muted mt-2.5 font-light italic">{latest.date}</p>
+  </div>
+
+  <!-- Sleep Score -->
+  <div class="bg-card rounded-2xl border border-border p-6 shadow-sm">
+    <p class="text-[0.65rem] font-medium tracking-[0.12em] uppercase text-ink-muted mb-3">睡眠スコア</p>
+    {latest.score != null ? (
+      <p class="font-display text-2xl md:text-4xl font-semibold tracking-tight text-ink leading-none">
+        {latest.score}
+        <span class="text-base font-body font-normal text-ink-muted ml-0.5">/100</span>
+      </p>
+    ) : (
+      <p class="font-display text-2xl md:text-4xl font-semibold text-ink-muted leading-none">—</p>
+    )}
+  </div>
+
+  <!-- 7d Average -->
+  <div class="bg-card rounded-2xl border border-border p-6 shadow-sm">
+    <p class="text-[0.65rem] font-medium tracking-[0.12em] uppercase text-ink-muted mb-3">7日平均</p>
+    <p class="font-display text-2xl md:text-4xl font-semibold tracking-tight text-ink leading-none">
+      {formatDuration(avg7dSleepTime)}
+    </p>
+  </div>
+
+  <!-- Deep Sleep -->
+  <div class="bg-card rounded-2xl border border-border p-6 shadow-sm">
+    <p class="text-[0.65rem] font-medium tracking-[0.12em] uppercase text-ink-muted mb-3">深い睡眠</p>
+    {latest.deep > 0 ? (
+      <p class="font-display text-2xl md:text-4xl font-semibold tracking-tight text-ink leading-none">
+        {formatDuration(latest.deep)}
+      </p>
+    ) : (
+      <p class="font-display text-2xl md:text-4xl font-semibold text-ink-muted leading-none">—</p>
+    )}
+    {deepRatioPercent != null && (
+      <p class="text-xs text-ink-muted mt-2.5 font-light italic">全体の {deepRatioPercent}%</p>
+    )}
+  </div>
+</div>

--- a/dashboard/src/lib/sleep.ts
+++ b/dashboard/src/lib/sleep.ts
@@ -1,0 +1,110 @@
+import fs from "node:fs";
+import path from "node:path";
+
+interface RawSleepRecord {
+  date: string;
+  start_at: string;
+  end_at: string;
+  total_sleep_time: number | null;
+  total_time_in_bed?: number | null;
+  sleep_efficiency?: number | null;
+  deep_sleep_duration?: number | null;
+  light_sleep_duration?: number | null;
+  rem_sleep_duration?: number | null;
+  waso?: number | null;
+  wakeup_count?: number | null;
+  sleep_score?: number | null;
+  hr_average?: number | null;
+}
+
+export interface SleepRecord {
+  date: string; // YYYY-MM-DD
+  totalSleepTime: number; // 秒
+  deep: number; // 秒 (欠損は 0)
+  light: number;
+  rem: number;
+  waso: number;
+  score: number | null;
+  hrAverage: number | null;
+  wakeupCount: number | null;
+  efficiency: number | null; // 0-1
+}
+
+export interface SleepStats {
+  latest: SleepRecord;
+  avg7dSleepTime: number; // 秒
+  deepRatioPercent: number | null; // 最新夜の深い睡眠比率 (%)
+}
+
+export function formatDuration(seconds: number): string {
+  const totalMinutes = Math.round(seconds / 60);
+  const h = Math.floor(totalMinutes / 60);
+  const m = totalMinutes % 60;
+  return `${h}h ${String(m).padStart(2, "0")}m`;
+}
+
+export function loadSleepData(): SleepRecord[] {
+  // data.ts と同様、Astro v6 の prerender 中は process.cwd() が
+  // dashboard ディレクトリを指す
+  const dataPath = path.resolve(process.cwd(), "../sleep.jsonl");
+  if (!fs.existsSync(dataPath)) {
+    return [];
+  }
+  const raw = fs.readFileSync(dataPath, "utf-8").trim();
+  if (raw === "") {
+    return [];
+  }
+
+  const records = raw
+    .split("\n")
+    .map((line: string) => JSON.parse(line) as RawSleepRecord)
+    .filter((r: RawSleepRecord) => r.total_sleep_time != null);
+
+  // 同一日に複数レコード (昼寝など) がある場合はメイン睡眠 = 最長を採用
+  const byDate = new Map<string, RawSleepRecord>();
+  for (const r of records) {
+    const existing = byDate.get(r.date);
+    if (
+      existing == null ||
+      (r.total_sleep_time ?? 0) > (existing.total_sleep_time ?? 0)
+    ) {
+      byDate.set(r.date, r);
+    }
+  }
+
+  return Array.from(byDate.values())
+    .map((r) => ({
+      date: r.date,
+      totalSleepTime: r.total_sleep_time!,
+      deep: r.deep_sleep_duration ?? 0,
+      light: r.light_sleep_duration ?? 0,
+      rem: r.rem_sleep_duration ?? 0,
+      waso: r.waso ?? 0,
+      score: r.sleep_score ?? null,
+      hrAverage: r.hr_average ?? null,
+      wakeupCount: r.wakeup_count ?? null,
+      efficiency: r.sleep_efficiency ?? null,
+    }))
+    .sort((a, b) => a.date.localeCompare(b.date));
+}
+
+export function calcSleepStats(data: SleepRecord[]): SleepStats | null {
+  if (data.length === 0) return null;
+
+  const latest = data[data.length - 1];
+
+  // 直近7日 (日付基準) に記録がある夜の平均
+  const cutoff = new Date(latest.date);
+  cutoff.setDate(cutoff.getDate() - 6);
+  const cutoffStr = cutoff.toISOString().split("T")[0];
+  const recent = data.filter((r) => r.date >= cutoffStr);
+  const avg7dSleepTime =
+    recent.reduce((sum, r) => sum + r.totalSleepTime, 0) / recent.length;
+
+  const deepRatioPercent =
+    latest.deep > 0 && latest.totalSleepTime > 0
+      ? Math.round((latest.deep / latest.totalSleepTime) * 100)
+      : null;
+
+  return { latest, avg7dSleepTime, deepRatioPercent };
+}

--- a/dashboard/src/pages/index.astro
+++ b/dashboard/src/pages/index.astro
@@ -7,6 +7,8 @@ import BodyCompChart from "../components/BodyCompChart.astro";
 import MetabolicsCards from "../components/MetabolicsCards.astro";
 import MonthlyTrend from "../components/MonthlyTrend.astro";
 import YearlyStats from "../components/YearlyStats.astro";
+import SleepSummaryCards from "../components/SleepSummaryCards.astro";
+import SleepChart from "../components/SleepChart.astro";
 import {
   loadData,
   calcMovingAverage,
@@ -14,12 +16,16 @@ import {
   calcYearlyStats,
   calcWeekOverWeek,
 } from "../lib/data";
+import { loadSleepData, calcSleepStats } from "../lib/sleep";
 
 const data = loadData();
 const movingAvg = calcMovingAverage(data, 30);
 const monthlyAvg = calcMonthlyAvg(data);
 const yearlyStats = calcYearlyStats(data);
 const weekOverWeek = calcWeekOverWeek(data);
+
+const sleepData = loadSleepData();
+const sleepStats = calcSleepStats(sleepData);
 
 const latest = data[data.length - 1];
 const latestMA = movingAvg[movingAvg.length - 1];
@@ -37,6 +43,14 @@ const latestMA = movingAvg[movingAvg.length - 1];
   <FatChart data={data} movingAvg={movingAvg} />
   <MetabolicsCards data={data} />
   <BodyCompChart data={data} />
+  {
+    sleepStats && (
+      <>
+        <SleepSummaryCards stats={sleepStats} />
+        <SleepChart data={sleepData} />
+      </>
+    )
+  }
   <MonthlyTrend data={monthlyAvg} />
   <YearlyStats data={yearlyStats} />
 </Layout>


### PR DESCRIPTION
## Summary
- `dashboard/src/lib/sleep.ts` — sleep.jsonl のロード (不在なら空、同一日の昼寝レコードは最長を採用、`total_sleep_time` null 行はスキップ)、7日平均などの集計、`"7h 23m"` フォーマッタ
- `SleepSummaryCards.astro` — カード4枚: 昨夜の睡眠 / 睡眠スコア / 7日平均 / 深い睡眠 (割合付き)。欠損は「—」
- `SleepChart.astro` — 深い・浅い・REM・中途覚醒の積み上げバー。1M/3M/6M/1Y/ALL 期間ボタン、ツールチップに各ステージ + 合計 + スコア + 中途覚醒回数
- `index.astro` — ボディコンポジションの後に挿入。**sleep.jsonl にデータが無い間はセクションごと非表示** (現状はこの状態でビルド成功を確認済み)

## Test plan
- [x] sleep.jsonl 無しで `pnpm build` 成功・睡眠セクション非表示
- [x] サンプル 56 夜分 (スコア欠損・昼寝重複・null 行含む) で build し、埋め込みデータの重複排除・null 除外・カード値を検証
- [ ] マージ後、実データ同期開始時に表示を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)