### PR TITLE
Add concurrency group to update_metrics workflow

### DIFF
--- a/.github/workflows/update_metrics.yml
+++ b/.github/workflows/update_metrics.yml
@@ -7,6 +7,10 @@ on:
     - cron: "0 0 * * *" # フォールバック: 毎日 JST 9:00
   workflow_dispatch: {}
 
+concurrency:
+  group: update-metrics
+  cancel-in-progress: true
+
 jobs:
   sync:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- `update_metrics.yml` に `concurrency: update-metrics` / `cancel-in-progress: true` を追加
- `weight_updated` と `sleep_updated` の repository_dispatch がほぼ同時に来た際、両 run が同じ古い main を checkout して後発の push が non-fast-forward で失敗する問題（run #29128204290）への対策

## Test plan
- [ ] マージ後、体重・睡眠の同時同期で run が失敗しないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017oXK1Lhdhs12gRBjixiv3g