### PR TITLE
Regenerate sleep.jsonl from full D1 snapshot on each sync

### DIFF
--- a/.github/workflows/update_metrics.yml
+++ b/.github/workflows/update_metrics.yml
@@ -61,34 +61,28 @@ jobs:
             echo "latest_muscle=${latest_muscle}" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Get last synced sleep datetime
-        id: last_sleep_date
-        run: |
-          if [ -f sleep.jsonl ]; then
-            last=$(tail -1 sleep.jsonl | jq -r '.start_at')
-            echo "datetime=${last}" >> "$GITHUB_OUTPUT"
-          else
-            echo "datetime=2024-03-19 00:00:00+09:00" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Fetch new sleep data from D1
+      # 睡眠は D1 側が UPSERT (後日更新・バックフィルあり) のため、
+      # 差分追記ではなく毎回全件を取得して sleep.jsonl を再生成する
+      - name: Fetch sleep data from D1
         id: fetch_sleep
         run: |
           response=$(curl -sf -X POST \
             "https://api.cloudflare.com/client/v4/accounts/${{ secrets.CLOUDFLARE_ACCOUNT_ID }}/d1/database/${{ secrets.D1_DATABASE_ID }}/query" \
             -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" \
             -H "Content-Type: application/json" \
-            -d "{\"sql\": \"SELECT date, start_at, end_at, total_sleep_time, total_time_in_bed, sleep_efficiency, sleep_latency, wakeup_latency, waso, nb_rem_episodes, light_sleep_duration, deep_sleep_duration, rem_sleep_duration, wakeup_count, wakeup_duration, out_of_bed_count, hr_average, hr_min, hr_max, rr_average, rr_min, rr_max, snoring, snoring_episode_count, sleep_score, apnea_hypopnea_index, breathing_disturbances_intensity, night_events FROM sleep_summaries WHERE start_at > ? ORDER BY start_at ASC\", \"params\": [\"${{ steps.last_sleep_date.outputs.datetime }}\"]}")
+            -d "{\"sql\": \"SELECT date, start_at, end_at, total_sleep_time, total_time_in_bed, sleep_efficiency, sleep_latency, wakeup_latency, waso, nb_rem_episodes, light_sleep_duration, deep_sleep_duration, rem_sleep_duration, wakeup_count, wakeup_duration, out_of_bed_count, hr_average, hr_min, hr_max, rr_average, rr_min, rr_max, snoring, snoring_episode_count, sleep_score, apnea_hypopnea_index, breathing_disturbances_intensity, night_events, stage_segments FROM sleep_summaries ORDER BY start_at ASC\"}")
 
-          count=$(echo "$response" | jq '.result[0].results | length')
-          echo "count=${count}" >> "$GITHUB_OUTPUT"
-
-          if [ "$count" -gt 0 ]; then
-            echo "$response" | jq -c '.result[0].results[]' >> sleep.jsonl
+          echo "$response" | jq -c '.result[0].results[]' > sleep.jsonl.new
+          if [ -f sleep.jsonl ] && cmp -s sleep.jsonl sleep.jsonl.new; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            rm sleep.jsonl.new
+          else
+            mv sleep.jsonl.new sleep.jsonl
+            echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Commit and push
-        if: steps.fetch.outputs.count != '0' || steps.fetch_sleep.outputs.count != '0'
+        if: steps.fetch.outputs.count != '0' || steps.fetch_sleep.outputs.changed == 'true'
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"


### PR DESCRIPTION
## Summary
- 睡眠の同期を「最終 `start_at` 以降の差分追記」から「全件取得して `sleep.jsonl` を再生成」に変更
  - D1 側は UPSERT（Withings の後日更新・バックフィル）のため、追記方式では過去分の追加・既存行の更新が永久に反映されない
  - 睡眠データは高々数百行なので全件取得のコストは無視できる
- `stage_segments`（睡眠ステージ時系列、cf-withings#63 で追加）を SELECT に追加
- commit 条件を件数ベースからファイル差分ベース（`cmp`）に変更

## Test plan
- [ ] マージ後 `workflow_dispatch` で実行し、sleep.jsonl が全件再生成されることを確認
- [ ] cf-withings#63 デプロイ＋バックフィル後、stage_segments が sleep.jsonl に入ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017oXK1Lhdhs12gRBjixiv3g