### PR TITLE
Color sleep schedule bars by stage (hypnogram)

### DIFF
--- a/dashboard/src/components/SleepChart.astro
+++ b/dashboard/src/components/SleepChart.astro
@@ -171,6 +171,35 @@ const dataJson = JSON.stringify(data);
     const yMax = wakeVals.length > 0 ? Math.ceil(Math.max(...wakeVals)) + 1 : 10;
     const fmtClock = (v: number) => `${((Math.round(v) % 24) + 24) % 24}:00`;
 
+    // 既存ステージグラフと同じパレット
+    const STAGE_COLORS: Record<number, string> = {
+      0: "rgba(156, 163, 175, 0.5)", // 覚醒
+      1: "rgba(99, 102, 241, 0.45)", // 浅い
+      2: "rgba(67, 56, 202, 0.85)", // 深い
+      3: "rgba(129, 140, 248, 0.35)", // REM
+    };
+    const FALLBACK_SEG_COLOR = "rgba(156, 163, 175, 0.3)"; // 未知の state
+    const TRANSPARENT = "rgba(0, 0, 0, 0)";
+
+    // dataset 0 (アンカー): 全夜の [就寝, 起床]。ツールチップはこれにだけ出す。
+    // ステージ区間がある夜は透明にして、上に重ねる区間データセットで色分けする
+    const anchorColors = data.map((d: any) =>
+      d.stageSegments ? TRANSPARENT : "rgba(99, 102, 241, 0.6)",
+    );
+    const maxSegs = Math.max(0, ...data.map((d: any) => d.stageSegments?.length ?? 0));
+    const segData = Array.from({ length: maxSegs }, (_, i) =>
+      data.map((d: any) => {
+        const s = d.stageSegments?.[i];
+        return s ? [s.startH, s.endH] : null;
+      }),
+    );
+    const segColors = Array.from({ length: maxSegs }, (_, i) =>
+      data.map((d: any) => {
+        const s = d.stageSegments?.[i];
+        return s ? (STAGE_COLORS[s.state] ?? FALLBACK_SEG_COLOR) : TRANSPARENT;
+      }),
+    );
+
     const scheduleChart = new Chart(
       document.getElementById("sleep-schedule-chart") as HTMLCanvasElement,
       {
@@ -180,10 +209,17 @@ const dataJson = JSON.stringify(data);
           datasets: [
             {
               data: allSchedule,
-              backgroundColor: "rgba(99, 102, 241, 0.6)",
+              backgroundColor: anchorColors,
               borderRadius: 4,
               borderSkipped: false,
+              grouped: false,
             },
+            ...segData.map((sd, i) => ({
+              data: sd,
+              backgroundColor: segColors[i],
+              borderSkipped: false,
+              grouped: false,
+            })),
           ],
         },
         options: {
@@ -191,7 +227,30 @@ const dataJson = JSON.stringify(data);
           maintainAspectRatio: false,
           interaction: { mode: "index", intersect: false },
           plugins: {
-            legend: { display: false },
+            legend: {
+              display: maxSegs > 0,
+              position: "top",
+              onClick: () => {},
+              labels: {
+                font: { family: "'Plus Jakarta Sans', system-ui", size: 11 },
+                color: "#6b7280",
+                usePointStyle: true,
+                pointStyle: "circle",
+                padding: 16,
+                generateLabels: () =>
+                  [
+                    ["深い", 2],
+                    ["浅い", 1],
+                    ["REM", 3],
+                    ["覚醒", 0],
+                  ].map(([text, state]) => ({
+                    text: text as string,
+                    fillStyle: STAGE_COLORS[state as number],
+                    strokeStyle: STAGE_COLORS[state as number],
+                    pointStyle: "circle" as const,
+                  })),
+              },
+            },
             tooltip: {
               backgroundColor: "#fff",
               titleColor: "#1a1a1a",
@@ -204,6 +263,8 @@ const dataJson = JSON.stringify(data);
               cornerRadius: 12,
               boxPadding: 6,
               displayColors: false,
+              // 夜単位の情報はアンカー (dataset 0) にだけ出す
+              filter: (item: any) => item.datasetIndex === 0,
               callbacks: {
                 label: (item: any) => {
                   const idx = allDates.indexOf(item.chart.data.labels[item.dataIndex]);
@@ -255,6 +316,11 @@ const dataJson = JSON.stringify(data);
       chart.update();
       scheduleChart.data.labels = allDates.slice(startIdx);
       scheduleChart.data.datasets[0].data = allSchedule.slice(startIdx);
+      (scheduleChart.data.datasets[0] as any).backgroundColor = anchorColors.slice(startIdx);
+      segData.forEach((sd, i) => {
+        scheduleChart.data.datasets[i + 1].data = sd.slice(startIdx);
+        (scheduleChart.data.datasets[i + 1] as any).backgroundColor = segColors[i].slice(startIdx);
+      });
       scheduleChart.update();
     }
 

--- a/dashboard/src/lib/sleep.ts
+++ b/dashboard/src/lib/sleep.ts
@@ -15,6 +15,7 @@ interface RawSleepRecord {
   wakeup_count?: number | null;
   sleep_score?: number | null;
   hr_average?: number | null;
+  stage_segments?: string | null;
 }
 
 export interface SleepRecord {
@@ -33,6 +34,8 @@ export interface SleepRecord {
   bedTime: string | null; // "23:33"
   wakeTime: string | null; // "07:27"
   timeInBed: number | null; // 秒
+  // 夜の中のステージ区間 (date の 0:00 基準の時間)。state: 0=覚醒, 1=浅い, 2=深い, 3=REM
+  stageSegments: { startH: number; endH: number; state: number }[] | null;
 }
 
 export interface SleepStats {
@@ -64,6 +67,30 @@ function parseClockOffset(
   const dayDiff =
     (Date.UTC(+y, +mo - 1, +d) - Date.UTC(by, bm - 1, bd)) / 86_400_000;
   return { offsetH: dayDiff * 24 + +h + +mi / 60, clock: `${h}:${mi}` };
+}
+
+// stage_segments ([[start_at からのオフセット秒, 長さ秒, state], ...] の JSON) を
+// date の 0:00 基準の時間区間に変換する。就寝〜起床の範囲にクリップし、不正は null
+function parseStageSegments(
+  raw: string | null | undefined,
+  bedOffsetH: number | null,
+  wakeOffsetH: number | null,
+): { startH: number; endH: number; state: number }[] | null {
+  if (!raw || bedOffsetH == null || wakeOffsetH == null) return null;
+  try {
+    const arr = JSON.parse(raw);
+    if (!Array.isArray(arr) || arr.length === 0) return null;
+    const segs = arr
+      .map(([off, dur, state]: number[]) => ({
+        startH: Math.max(bedOffsetH + off / 3600, bedOffsetH),
+        endH: Math.min(bedOffsetH + (off + dur) / 3600, wakeOffsetH),
+        state,
+      }))
+      .filter((s) => s.endH > s.startH);
+    return segs.length > 0 ? segs : null;
+  } catch {
+    return null;
+  }
 }
 
 export function loadSleepData(): SleepRecord[] {
@@ -119,6 +146,11 @@ export function loadSleepData(): SleepRecord[] {
           (bed && wake
             ? Math.round((wake.offsetH - bed.offsetH) * 3600)
             : null),
+        stageSegments: parseStageSegments(
+          r.stage_segments,
+          bed?.offsetH ?? null,
+          wake?.offsetH ?? null,
+        ),
       };
     })
     .sort((a, b) => a.date.localeCompare(b.date));


### PR DESCRIPTION
## Summary
- `sleep.ts`: `stage_segments`（[[オフセット秒, 長さ秒, state], ...]）をパースして `stageSegments`（date 0:00 基準の時間区間）に変換。就寝〜起床でクリップ、不正データは null
- `SleepChart.astro`（就寝・起床タブ）: バーを「透明アンカー + 区間データセット群（`grouped: false` で重ね描き）」に変更し、覚醒/浅い/深い/REM を既存ステージグラフと同じパレットで色分け
- ツールチップは `filter` でアンカーのみ（夜単位の既存内容を維持）、凡例は固定4ステージ、期間フィルタは全データセット対応
- ステージデータがない夜は従来どおり単色バーでフォールバック

#126 (feat/sleep-schedule-chart) の上に積むスタック PR。データ側は cf-withings#63 と #128 が前提

## Test plan
- [x] `pnpm run build` が通る
- [x] テストデータ注入で stageSegments のパース結果を検証（区間の連結・クリップ・フォールバック）
- [ ] cf-withings#63 デプロイ + バックフィル + #128 マージ後、実データで色分け表示を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017oXK1Lhdhs12gRBjixiv3g