### PR TITLE
Don't cancel in-progress Pages deploys from skipped runs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,9 @@ permissions:
 
 concurrency:
   group: pages
-  cancel-in-progress: true
+  # true にすると、if 条件で全ジョブが skip される run (失敗した sync 由来など)
+  # でも起動した瞬間に実行中のデプロイをキャンセルしてしまうため false にする
+  cancel-in-progress: false
 
 defaults:
   run:


### PR DESCRIPTION
## Summary
- deploy.yml の `cancel-in-progress` を `true` → `false` に変更
- workflow レベルの concurrency は job の `if` 判定より先に評価されるため、失敗/キャンセルされた sync 由来の「全ジョブが skip される deploy run」でも、起動した瞬間に実行中の本物のデプロイをキャンセルしてしまう（2026-07-10 夜にデプロイが抜けた原因）
- false（キューイング）にしても Pages のビルドは1〜2分なので実害なし

## Test plan
- [ ] マージ後、sync 失敗時にも実行中のデプロイがキャンセルされないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017oXK1Lhdhs12gRBjixiv3g